### PR TITLE
Add Elixir specific font face for function calls

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -105,6 +105,10 @@
   '((t (:inherit default)))
   "For use with numbers.")
 
+(defvar elixir-function-call-face 'elixir-function-call-face)
+(defface elixir-function-call-face
+  '((t (:inherit font-lock-function-name-face)))
+  "For use with function calls.")
 
 (eval-when-compile
   (defconst elixir-rx-constituents
@@ -433,7 +437,7 @@ is used to limit the scan."
     (,(elixir-rx word-boundary
                  (group identifiers)
                  (repeat 1 "("))
-     1 font-lock-constant-face)
+     1 elixir-function-call-face)
 
     ;; Map keys
     (,(elixir-rx (group (and identifiers ":")) (or space "\n"))


### PR DESCRIPTION
I'm not sure how you feel about this, but it let's the user specify the color of the function calls if they want, otherwise it will default to the same as the function definition face.

If we use a font-lock face like keyword or constant, we can only change that group. So I like the flexibility this gives and the default is nice too.

Example doom-emacs color theme definition: 
```elisp
   (elixir-function-call-face :foreground cyan)
```
